### PR TITLE
Fix PVE Mode not filtering NPC damage

### DIFF
--- a/src/LogMonitor.ahk
+++ b/src/LogMonitor.ahk
@@ -636,7 +636,7 @@ Class LogMonitor {
                 ; PVE mode: extract attacker and skip if NPC
                 if (this._pveMode) {
                     attacker := this._ExtractAttacker(line)
-                    if (attacker != "" && this._IsNPC(attacker))
+                    if (attacker != "" && this._IsNPC(attacker.name, attacker.info))
                         return
                 }
                 this._EmitEvent(charName, "attack", LogMonitor.SEV_CRITICAL,
@@ -653,7 +653,7 @@ Class LogMonitor {
                 ; PVE mode: extract attacker and skip if NPC
                 if (this._pveMode) {
                     attacker := this._ExtractAttacker(line)
-                    if (attacker != "" && this._IsNPC(attacker))
+                    if (attacker != "" && this._IsNPC(attacker.name, attacker.info))
                         return
                 }
                 this._EmitEvent(charName, "warp_scramble", LogMonitor.SEV_CRITICAL,
@@ -929,24 +929,30 @@ Class LogMonitor {
         return Trim(system)
     }
 
-    ; Extract attacker name from a combat log line
-    ; Format: "... from <b>Attacker Name</b> - WeaponName ..."
+    ; Extract attacker name and trailing info from a combat log line
+    ; Format: "... from <b>Attacker Name</b>[CORP](Ship) - WeaponName ..."
     _ExtractAttacker(line) {
-        ; Look for "from" followed by <b>name</b>
-        if RegExMatch(line, "from\s*(?:<[^>]*>)*\s*<b>(.+?)</b>", &m)
-            return Trim(m[1])
+        ; Look for "from" followed by <b>name</b> and capture the trailing part
+        if RegExMatch(line, "from\s*(?:<[^>]*>)*\s*<b>(.+?)</b>(.*)", &m)
+            return { name: Trim(m[1]), info: m[2] }
+        
         ; Fallback: look for any <b> tag after "from"
         fromPos := InStr(line, "from")
         if (fromPos > 0) {
             rest := SubStr(line, fromPos)
-            if RegExMatch(rest, "<b>(.+?)</b>", &m)
-                return Trim(m[1])
+            if RegExMatch(rest, "<b>(.+?)</b>(.*)", &m)
+                return { name: Trim(m[1]), info: m[2] }
         }
         return ""
     }
 
-    ; Check if a name matches known NPC naming patterns
-    _IsNPC(name) {
+    ; Check if a name matches known NPC naming patterns or heuristics
+    _IsNPC(name, info := "") {
+        ; Heuristic: Player characters always have [CORP] tag and often (Ship) type
+        ; immediately following their name in combat logs. NPCs never do.
+        if (info != "" && (InStr(info, "[") || InStr(info, "(")))
+            return false
+
         ; Check prefixes
         for idx, prefix in LogMonitor.NPC_PREFIXES {
             if (SubStr(name, 1, StrLen(prefix)) = prefix)
@@ -957,6 +963,13 @@ Class LogMonitor {
             if (SubStr(name, -StrLen(suffix)) = suffix)
                 return true
         }
+
+        ; Fallback: If it has no brackets/parens and doesn't match a faction,
+        ; it's still likely an NPC (like 'Tower Sentry Gun' or 'Athanor')
+        ; We assume it's an NPC if info is present but lacks brackets.
+        if (info != "")
+            return true
+
         return false
     }
 }

--- a/src/StatTracker.ahk
+++ b/src/StatTracker.ahk
@@ -272,31 +272,34 @@ Class StatTracker {
         return false  ; Default: NPC damage NOT counted
     }
 
-    ; Extract entity name from combat line (target for "to", source for "from")
+    ; Extract entity name and info from combat line (target for "to", source for "from")
     _ExtractEntity(line) {
         ; Try "to" entity (outgoing damage target)
-        if (RegExMatch(line, "to</font>.*?<b>(.*?)</b>", &m))
-            return Trim(RegExReplace(m[1], '<[^>]+>', ''))
+        if (RegExMatch(line, "to</font>.*?<b>(.*?)</b>(.*)", &m))
+            return { name: Trim(RegExReplace(m[1], '<[^>]+>', '')), info: m[2] }
         ; Try "from" entity (incoming damage source)
-        if (RegExMatch(line, "from</font>.*?<b>(.*?)</b>", &m))
-            return Trim(RegExReplace(m[1], '<[^>]+>', ''))
+        if (RegExMatch(line, "from</font>.*?<b>(.*?)</b>(.*)", &m))
+            return { name: Trim(RegExReplace(m[1], '<[^>]+>', '')), info: m[2] }
         ; Fallback: logi/cap lines
-        if (RegExMatch(line, "(?:to|by)\s+</font>.*?<b>(.*?)</b>", &m))
-            return Trim(RegExReplace(m[1], '<[^>]+>', ''))
+        if (RegExMatch(line, "(?:to|by)\s+</font>.*?<b>(.*?)</b>(.*)", &m))
+            return { name: Trim(RegExReplace(m[1], '<[^>]+>', '')), info: m[2] }
         return ""
     }
 
-    ; Check if an entity name is an NPC
-    _IsNpcEntity(name) {
-        if (name = "")
+    ; Check if an entity is an NPC
+    _IsNpcEntity(entity) {
+        if (entity = "" || entity.name = "")
             return false
+        
         ; Delegate to LogMonitor's comprehensive NPC check if available
         try {
             logMon := this._mainRef._LogMonitor
-            return logMon._IsNPC(name)
+            return logMon._IsNPC(entity.name, entity.info)
         }
-        ; Fallback heuristic: players have [CORP](Ship), NPCs don't
-        return (!InStr(name, "[") && !InStr(name, "("))
+        
+        ; Fallback heuristic: Player characters always have [CORP] tag or (Ship) type
+        ; immediately following their name in combat logs. NPCs never do.
+        return !(InStr(entity.info, "[") || InStr(entity.info, "("))
     }
 
     ; ==================== Rate Calculations ====================


### PR DESCRIPTION
## Fix PVE Mode not filtering NPC damage

**Fixes #5**

### Problem
The "PVE Mode (Ignore NPC Damage)" setting was failing to filter out NPC/rat/sentry damage, causing attack alerts to trigger even when the mode was enabled.

### Solution
Enhanced NPC detection by capturing and analysing the full combat log formatting:

- Modified `_ExtractAttacker()` to capture both the entity name and trailing information (corp tags, ship types)
- Updated `_IsNPC()` to use a heuristic: player characters in EVE combat logs always have `[CORP]` tags or `(Ship)` types immediately following their name, while NPCs never do
- Applied the same robust filtering logic to both `LogMonitor.ahk` and `StatTracker.ahk` for consistency

This approach is more reliable than prefix/suffix matching alone, as it uses the inherent formatting differences in how EVE logs player vs NPC entities.

### Testing
- Attack alerts no longer trigger for NPC/rat/sentry damage when PVE Mode is enabled
- Player damage still triggers alerts correctly
- Combat statistics now properly exclude NPC damage in PVE mode