### PR TITLE
Fix DPI scaling on high-DPI monitors (#15)

### DIFF
--- a/EveMultiPreview.csproj
+++ b/EveMultiPreview.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
+    <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
     <AssemblyName>EVE MultiPreview</AssemblyName>
     <RootNamespace>EveMultiPreview</RootNamespace>
     <Version>2.0.3</Version>

--- a/Interop/DpiHelper.cs
+++ b/Interop/DpiHelper.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Media;
+
+namespace EveMultiPreview.Interop;
+
+/// <summary>
+/// Converts between WPF DIPs (Device Independent Pixels) and Win32 physical pixels.
+/// WPF properties (Left, Top, Width, Height, ActualWidth) are in DIPs.
+/// Win32 APIs (SetWindowPos, GetWindowRect, DWM thumbnail, Cursor.Position) use physical pixels.
+/// At 150% scaling: 100 DIPs = 150 physical pixels.
+/// </summary>
+public static class DpiHelper
+{
+    /// <summary>
+    /// Get the DPI scale factor for a specific WPF visual.
+    /// Returns 1.0 at 100%, 1.25 at 125%, 1.5 at 150%, 2.0 at 200%.
+    /// </summary>
+    public static double GetScaleFactor(Visual visual)
+    {
+        try
+        {
+            return VisualTreeHelper.GetDpi(visual).DpiScaleX;
+        }
+        catch (InvalidOperationException)
+        {
+            return GetSystemScaleFactor();
+        }
+    }
+
+    /// <summary>
+    /// Get the system-wide DPI scale factor (fallback when no visual is available).
+    /// </summary>
+    public static double GetSystemScaleFactor()
+    {
+        IntPtr hdc = GetDC(IntPtr.Zero);
+        if (hdc != IntPtr.Zero)
+        {
+            try
+            {
+                int dpiX = GetDeviceCaps(hdc, LOGPIXELSX);
+                return dpiX / 96.0;
+            }
+            finally
+            {
+                ReleaseDC(IntPtr.Zero, hdc);
+            }
+        }
+        return 1.0;
+    }
+
+    /// <summary>
+    /// Get the DPI scale factor for a specific monitor, identified by a point on it.
+    /// Uses GetDpiForMonitor (Win 8.1+) for per-monitor accuracy in mixed-DPI setups.
+    /// </summary>
+    public static double GetScaleFactorForPoint(int x, int y)
+    {
+        IntPtr hMonitor = MonitorFromPoint(new POINT(x, y), MONITOR_DEFAULTTONEAREST);
+        if (hMonitor != IntPtr.Zero &&
+            GetDpiForMonitor(hMonitor, MDT_EFFECTIVE_DPI, out uint dpiX, out _) == 0)
+            return dpiX / 96.0;
+        return GetSystemScaleFactor();
+    }
+
+    /// <summary>Convert WPF DIPs to physical pixels.</summary>
+    public static int DipToPhysical(double dip, double scale) =>
+        (int)Math.Round(dip * scale);
+
+    /// <summary>Convert physical pixels to WPF DIPs.</summary>
+    public static double PhysicalToDip(double pixels, double scale) =>
+        scale > 0 ? pixels / scale : pixels;
+
+    private const int LOGPIXELSX = 88;
+    private const uint MDT_EFFECTIVE_DPI = 0;
+    private const uint MONITOR_DEFAULTTONEAREST = 2;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct POINT
+    {
+        public int X, Y;
+        public POINT(int x, int y) { X = x; Y = y; }
+    }
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetDC(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
+
+    [DllImport("gdi32.dll")]
+    private static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr MonitorFromPoint(POINT pt, uint dwFlags);
+
+    [DllImport("shcore.dll")]
+    private static extern int GetDpiForMonitor(IntPtr hMonitor, uint dpiType, out uint dpiX, out uint dpiY);
+}

--- a/Services/ThumbnailManager.cs
+++ b/Services/ThumbnailManager.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Windows;
 using System.Windows.Threading;
+using EveMultiPreview.Interop;
 using EveMultiPreview.Models;
 using EveMultiPreview.Views;
 
@@ -256,11 +257,15 @@ public sealed class ThumbnailManager : IDisposable
         }
         else
         {
-            // Flow-layout: stack vertically, wrap to new column at screen edge
+            // Flow-layout: stack vertically, wrap to new column at screen edge.
+            // Screen.WorkingArea returns physical pixels; x/y/width/height are DIPs.
+            // Convert work area to DIPs for consistent math.
             int index = _thumbnails.Count;
             int gap = 8;
             var workArea = GetTargetMonitorWorkArea(s.PreferredMonitor);
-            int availableHeight = workArea.Bottom - y;
+            double dpiScale = DpiHelper.GetScaleFactorForPoint(
+                workArea.Left + workArea.Width / 2, workArea.Top + workArea.Height / 2);
+            int availableHeight = (int)DpiHelper.PhysicalToDip(workArea.Bottom, dpiScale) - y;
             int maxPerCol = Math.Max(1, availableHeight / (height + gap));
             int col = index / maxPerCol;
             int row = index % maxPerCol;
@@ -1136,8 +1141,9 @@ public sealed class ThumbnailManager : IDisposable
                 _tooltipWindow?.Close();
                 _tooltipTimer?.Stop();
 
-                // Get cursor position
+                // Get cursor position (physical pixels) and convert to DIPs for WPF properties
                 var cursorPos = System.Windows.Forms.Cursor.Position;
+                double dpi = DpiHelper.GetScaleFactorForPoint(cursorPos.X, cursorPos.Y);
 
                 // Create a small borderless tooltip window near the cursor (AHK ToolTip style)
                 _tooltipWindow = new System.Windows.Window
@@ -1149,8 +1155,8 @@ public sealed class ThumbnailManager : IDisposable
                     Topmost = true,
                     ShowInTaskbar = false,
                     SizeToContent = SizeToContent.WidthAndHeight,
-                    Left = cursorPos.X + 16,
-                    Top = cursorPos.Y + 16,
+                    Left = DpiHelper.PhysicalToDip(cursorPos.X, dpi) + 16,
+                    Top = DpiHelper.PhysicalToDip(cursorPos.Y, dpi) + 16,
                     Content = new System.Windows.Controls.TextBlock
                     {
                         Text = message,

--- a/Views/StatOverlayWindow.xaml.cs
+++ b/Views/StatOverlayWindow.xaml.cs
@@ -255,16 +255,18 @@ public partial class StatOverlayWindow : Window
                 return;
             }
 
+            // Mouse delta is physical pixels (Cursor.Position); drag start values are DIPs.
             double dx = mouse.X - _dragStartScreen.X;
             double dy = mouse.Y - _dragStartScreen.Y;
+            double scale = DpiHelper.GetScaleFactor(this);
 
             if (!_dragMovedPastThreshold && (Math.Abs(dx) > 3 || Math.Abs(dy) > 3))
                 _dragMovedPastThreshold = true;
 
             if (_dragMovedPastThreshold)
             {
-                Left = _dragStartLeft + dx;
-                Top = _dragStartTop + dy;
+                Left = _dragStartLeft + DpiHelper.PhysicalToDip(dx, scale);
+                Top = _dragStartTop + DpiHelper.PhysicalToDip(dy, scale);
             }
         }
         else if (_dragMode == DragMode.Resize)
@@ -279,9 +281,10 @@ public partial class StatOverlayWindow : Window
 
             double dx = mouse.X - _dragStartScreen.X;
             double dy = mouse.Y - _dragStartScreen.Y;
+            double scale = DpiHelper.GetScaleFactor(this);
 
-            Width = Math.Max(80, _resizeStartWidth + dx);
-            Height = Math.Max(40, _resizeStartHeight + dy);
+            Width = Math.Max(80, _resizeStartWidth + DpiHelper.PhysicalToDip(dx, scale));
+            Height = Math.Max(40, _resizeStartHeight + DpiHelper.PhysicalToDip(dy, scale));
 
             // Ctrl+resize = individual only; no Ctrl = resize all stat windows
             if (!User32.IsKeyDown(User32.VK_LCONTROL))

--- a/Views/ThumbnailWindow.xaml.cs
+++ b/Views/ThumbnailWindow.xaml.cs
@@ -330,6 +330,8 @@ public partial class ThumbnailWindow : Window
                 return;
             }
 
+            // Mouse delta is in physical pixels (Cursor.Position).
+            // _dragStartLeft/Top are WPF DIPs — convert to physical before combining.
             double dx = mouse.X - _dragStartScreen.X;
             double dy = mouse.Y - _dragStartScreen.Y;
 
@@ -338,8 +340,9 @@ public partial class ThumbnailWindow : Window
 
             if (_dragMovedPastThreshold)
             {
-                int newX = (int)(_dragStartLeft + dx);
-                int newY = (int)(_dragStartTop + dy);
+                double scale = DpiHelper.GetScaleFactor(this);
+                int newX = (int)(DpiHelper.DipToPhysical(_dragStartLeft, scale) + dx);
+                int newY = (int)(DpiHelper.DipToPhysical(_dragStartTop, scale) + dy);
 
                 // Direct Win32 move — bypasses WPF layout engine entirely (matches AHK WinMove)
                 if (_ownHwnd != IntPtr.Zero)
@@ -352,10 +355,10 @@ public partial class ThumbnailWindow : Window
                     User32.SetWindowPos(overlayHwnd, IntPtr.Zero, newX, newY, 0, 0,
                         User32.SWP_NOSIZE | User32.SWP_NOZORDER | User32.SWP_NOACTIVATE);
 
-                // Ctrl+drag → move all thumbnails
+                // Ctrl+drag → move all thumbnails (convert physical delta to DIPs for WPF consumers)
                 if (User32.IsKeyDown(User32.VK_LCONTROL))
                 {
-                    DragMoveAll?.Invoke(this, dx, dy);
+                    DragMoveAll?.Invoke(this, DpiHelper.PhysicalToDip(dx, scale), DpiHelper.PhysicalToDip(dy, scale));
                 }
             }
         }
@@ -369,11 +372,13 @@ public partial class ThumbnailWindow : Window
                 return;
             }
 
+            // Mouse delta is physical pixels (Cursor.Position); resize start values are DIPs.
             double dx = mouse.X - _dragStartScreen.X;
             double dy = mouse.Y - _dragStartScreen.Y;
+            double scale = DpiHelper.GetScaleFactor(this);
 
-            int newW = Math.Max((int)(_resizeStartWidth + dx), 80);
-            int newH = Math.Max((int)(_resizeStartHeight + dy), 50);
+            int newW = Math.Max((int)(_resizeStartWidth + DpiHelper.PhysicalToDip(dx, scale)), 80);
+            int newH = Math.Max((int)(_resizeStartHeight + DpiHelper.PhysicalToDip(dy, scale)), 50);
 
             Width = newW;
             Height = newH;
@@ -400,12 +405,14 @@ public partial class ThumbnailWindow : Window
             _dragTimer = null;
         }
 
-        // Sync WPF Left/Top from actual Win32 position (drag used SetWindowPos, not WPF properties)
+        // Sync WPF Left/Top from actual Win32 position (drag used SetWindowPos, not WPF properties).
+        // GetWindowRect returns physical pixels; WPF Left/Top are DIPs.
         if (_ownHwnd != IntPtr.Zero)
         {
             User32.GetWindowRect(_ownHwnd, out var rect);
-            Left = rect.Left;
-            Top = rect.Top;
+            double scale = DpiHelper.GetScaleFactor(this);
+            Left = DpiHelper.PhysicalToDip(rect.Left, scale);
+            Top = DpiHelper.PhysicalToDip(rect.Top, scale);
             _textOverlay?.SyncPosition(Left, Top, Width, Height);
         }
     }
@@ -481,17 +488,25 @@ public partial class ThumbnailWindow : Window
     public void UpdateThumbnailSize()
     {
         if (_thumbId == IntPtr.Zero) return;
-        
+
         int w = (int)ActualWidth;
         int h = (int)ActualHeight;
         if (w == 0) w = (int)(double.IsNaN(Width) ? 0 : Width);
         if (h == 0) h = (int)(double.IsNaN(Height) ? 0 : Height);
-        
+
         int b = _borderThickness;
+
+        // DWM rcDestination expects physical pixels, but WPF ActualWidth/Height are in DIPs.
+        // At 150% scaling: 280 DIPs → 420 physical pixels.
+        double scale = DpiHelper.GetScaleFactor(this);
+        int pw = DpiHelper.DipToPhysical(w, scale);
+        int ph = DpiHelper.DipToPhysical(h, scale);
+        int pb = DpiHelper.DipToPhysical(b, scale);
+
         // Inset the DWM thumbnail by border thickness.
         // Because the WPF BackgroundPanel now uses true BorderBrush with a Transparent center,
         // passing _savedOpacity here natively blends the DWM thumbnail directly with the desktop.
-        DwmApi.UpdateThumbnailInset(_thumbId, w, h, b, _currentVisualOpacity);
+        DwmApi.UpdateThumbnailInset(_thumbId, pw, ph, pb, _currentVisualOpacity);
     }
 
     // ── Overlay Updates ─────────────────────────────────────────────
@@ -852,12 +867,7 @@ public partial class ThumbnailWindow : Window
         var overlayHwnd = _textOverlay.GetHwnd();
         if (overlayHwnd == IntPtr.Zero) return;
 
-        // Position-only sync — z-order is asserted one-time by BringToFront()
-        // at transition points (EVE gains focus, thumbnail switch), not every tick.
-        // This prevents the overlay from constantly fighting browser z-order.
-        User32.SetWindowPos(overlayHwnd, IntPtr.Zero,
-            (int)Left, (int)Top, (int)Width, (int)Height,
-            User32.SWP_NOACTIVATE | User32.SWP_NOZORDER);
+        SetOverlayWindowPos(overlayHwnd, IntPtr.Zero, User32.SWP_NOACTIVATE | User32.SWP_NOZORDER);
     }
 
     /// <summary>Bring both thumbnail and overlay to the front of the z-order.
@@ -875,16 +885,13 @@ public partial class ThumbnailWindow : Window
                 User32.SWP_NOACTIVATE | User32.SWP_NOMOVE | User32.SWP_NOSIZE);
         }
 
-        // Bring overlay above thumbnail
         if (_textOverlay != null)
         {
             var overlayHwnd = _textOverlay.GetHwnd();
             if (overlayHwnd != IntPtr.Zero)
             {
                 var zOrder = Topmost ? User32.HWND_TOPMOST : User32.HWND_TOP;
-                User32.SetWindowPos(overlayHwnd, zOrder,
-                    (int)Left, (int)Top, (int)Width, (int)Height,
-                    User32.SWP_NOACTIVATE);
+                SetOverlayWindowPos(overlayHwnd, zOrder, User32.SWP_NOACTIVATE);
             }
         }
     }
@@ -900,12 +907,19 @@ public partial class ThumbnailWindow : Window
         var overlayHwnd = _textOverlay.GetHwnd();
         if (overlayHwnd != IntPtr.Zero)
         {
-            // Re-assert overlay Topmost to match thumbnail (eve-o-preview pattern)
             var zOrder = Topmost ? User32.HWND_TOPMOST : User32.HWND_NOTOPMOST;
-            User32.SetWindowPos(overlayHwnd, zOrder,
-                (int)Left, (int)Top, (int)Width, (int)Height,
-                User32.SWP_NOACTIVATE | User32.SWP_SHOWWINDOW);
+            SetOverlayWindowPos(overlayHwnd, zOrder, User32.SWP_NOACTIVATE | User32.SWP_SHOWWINDOW);
         }
+    }
+
+    /// <summary>Position the text overlay via Win32, converting WPF DIPs to physical pixels.</summary>
+    private void SetOverlayWindowPos(IntPtr overlayHwnd, IntPtr zOrder, uint flags)
+    {
+        double scale = DpiHelper.GetScaleFactor(this);
+        User32.SetWindowPos(overlayHwnd, zOrder,
+            DpiHelper.DipToPhysical(Left, scale), DpiHelper.DipToPhysical(Top, scale),
+            DpiHelper.DipToPhysical(Width, scale), DpiHelper.DipToPhysical(Height, scale),
+            flags);
     }
 
     /// <summary>Set the topmost state for this thumbnail and its text overlay.


### PR DESCRIPTION
Thumbnails rendered incorrectly on displays with Windows scaling >100% (e.g., 4K at 150%, ultrawide at 125%). The root cause was WPF DIP values being passed directly to Win32 APIs that expect physical pixels.

- Add DpiHelper utility for DIP/physical pixel conversion
- Fix DWM thumbnail sizing (main visual bug - thumbnails filled only 67% of window at 150%)
- Fix drag move/resize mixing physical mouse deltas with DIP window properties
- Fix overlay positioning via SetWindowPos receiving DIP instead of physical coords
- Fix tooltip and initial layout using primary monitor DPI in mixed-DPI setups
- Add per-monitor DPI support via GetDpiForMonitor for multi-monitor setups
- Set explicit PerMonitorV2 DPI awareness mode in .csproj

The code was written with assistance from Claude, as I have little background in this projects languages.